### PR TITLE
Fix CI status checks not appearing in PR gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
           if-no-files-found: ignore
 
   report:
-    if: ${{ always() && github.event_name == 'pull_request_target' }}
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') }}
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -212,6 +212,9 @@ jobs:
       - uses: actions/download-artifact@v5
         if: ${{ always() }}
         continue-on-error: true
+        with:
+          pattern: "*-reports"
+          merge-multiple: true
 
       # - name: Convert JUnit XML to CTRF
       #   run: |
@@ -675,43 +678,16 @@ jobs:
             // Get step outcomes from the build job
             const buildJob = context.payload.workflow_run?.jobs?.find(job => job.name === 'build');
 
-            // Check each linting/formatting step result
-            const rustFmt = '${{ steps.rust-fmt.outcome }}';
-            const rustLint = '${{ steps.rust-lint.outcome }}';
-            const denoFmt = '${{ steps.deno-fmt.outcome }}';
-            const denoLint = '${{ steps.deno-lint.outcome }}';
-            const eslint = '${{ steps.eslint.outcome }}';
+            // Check the overall build job result (individual step outcomes aren't accessible across jobs)
+            const buildResult = '${{ needs.build.result }}';
+            console.log(`Build job result: ${buildResult}`);
 
-            console.log('Code Quality Step Results:');
-            console.log(`- Rust formatting: ${rustFmt}`);
-            console.log(`- Rust linter (Clippy): ${rustLint}`);
-            console.log(`- Deno formatting: ${denoFmt}`);
-            console.log(`- Deno linter: ${denoLint}`);
-            console.log(`- ESLint: ${eslint}`);
-
-            // Count failures
-            const checks = [
-              { name: 'Rust formatting', result: rustFmt },
-              { name: 'Rust linter', result: rustLint },
-              { name: 'Deno formatting', result: denoFmt },
-              { name: 'Deno linter', result: denoLint },
-              { name: 'ESLint', result: eslint }
-            ];
-
-            const failed = checks.filter(check => check.result === 'failure');
-            const passed = checks.filter(check => check.result === 'success');
-            const skipped = checks.filter(check => check.result === 'skipped');
-
-            const allPassed = failed.length === 0;
-            const state = allPassed ? 'success' : 'failure';
-
-            let description;
-            if (allPassed) {
-              description = `All code quality checks passed (${passed.length}/${checks.length})`;
-            } else {
-              const failedNames = failed.map(f => f.name).join(', ');
-              description = `Code quality issues: ${failedNames} (${passed.length}/${checks.length} passed)`;
-            }
+            // Since individual step outcomes aren't accessible across jobs, we'll base this on the overall build result
+            // In the future, this could be enhanced by storing step results as artifacts
+            const state = buildResult === 'success' ? 'success' : 'failure';
+            const description = buildResult === 'success' 
+              ? 'Build completed successfully'
+              : 'Build failed - check workflow for code quality issues';
 
             try {
               await github.rest.repos.createCommitStatus({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,27 +243,27 @@ jobs:
       - name: Combine coverage reports
         run: |
           echo "Combining coverage reports from all runtimes..."
-          
+
           # Create coverage-reports directory if it doesn't exist
           mkdir -p coverage-reports
           cd coverage-reports
-          
+
           # Copy coverage files from test-results/coverage to coverage-reports
           echo "Looking for coverage files..."
           ls -la ../test-results/coverage/ || echo "No test-results/coverage directory"
-          
+
           # Copy Rust coverage if it exists
           if [ -f ../test-results/coverage/rust.lcov ]; then
             echo "Found Rust coverage file"
             cp ../test-results/coverage/rust.lcov rust.lcov
           fi
-          
+
           # Copy Deno coverage if it exists
           if [ -f ../test-results/coverage/deno-lcov.info ]; then
             echo "Found Deno coverage file"
             cp ../test-results/coverage/deno-lcov.info deno-lcov.info
           fi
-          
+
           # Copy other coverage files if they exist
           if [ -d ../test-results/coverage/ ]; then
             cp ../test-results/coverage/*.info . 2>/dev/null || true
@@ -685,7 +685,7 @@ jobs:
             // Since individual step outcomes aren't accessible across jobs, we'll base this on the overall build result
             // In the future, this could be enhanced by storing step results as artifacts
             const state = buildResult === 'success' ? 'success' : 'failure';
-            const description = buildResult === 'success' 
+            const description = buildResult === 'success'
               ? 'Build completed successfully'
               : 'Build failed - check workflow for code quality issues';
 


### PR DESCRIPTION
The status checks weren't appearing in PRs because:

1. **Wrong Event Type**: The report job was only running for `pull_request_target` events, but normal PRs use `pull_request` events.

2. **Missing Artifact Download**: The artifact download step wasn't specifying which artifacts to download, so test reports weren't available for status check creation.

3. **Invalid Step References**: Code quality status check was trying to access step outcomes across jobs, which isn't supported.

Changes:
- Fix report job condition to run for both `pull_request` and `pull_request_target` events
- Add pattern and merge-multiple to artifact download for proper test report retrieval
- Simplify code quality status check to use overall build job result
- Remove invalid cross-job step outcome references

Now status checks should properly appear as PR gates:
- "Cross-Runtime Tests" - shows test pass/fail status
- "Code Quality" - shows build success/failure status

🤖 Generated with [Claude Code](https://claude.ai/code)