### PR TITLE
More secure relase flow and bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  release:
-    types: [created]
-  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*" # Trigger on version tags like v1.2.3
 
 jobs:
   test-cross-runtime:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "printers-js"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "lazy_static",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "printers-js"
 authors = ["Evan Simkowitz <esimkowitz@users.noreply.github.com>"]
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 publish = false
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@printers/printers",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "license": "MIT",
   "exports": {
     ".": "./index.ts"
@@ -41,9 +41,9 @@
     "fmt": "deno fmt",
     "check": "deno check deno.ts",
     "check:all": "deno check deno.ts && npm run build && echo 'All runtimes checked successfully'",
-    "bump:patch": "deno run --allow-read --allow-write scripts/bump-version.ts patch",
-    "bump:minor": "deno run --allow-read --allow-write scripts/bump-version.ts minor",
-    "bump:major": "deno run --allow-read --allow-write scripts/bump-version.ts major",
+    "bump:patch": "deno run -A scripts/bump-version.ts patch",
+    "bump:minor": "deno run -A scripts/bump-version.ts minor",
+    "bump:major": "deno run -A --allow-write scripts/bump-version.ts major",
     "docs": "deno doc --html --name=\"@printers/printers\" deno.ts index.ts",
     "docs:serve": "deno doc --serve --name=\"@printers/printers\" deno.ts index.ts"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@printers/printers",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@printers/printers",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "MIT",
       "devDependencies": {
         "@cross/test": "npm:@jsr/cross__test@^0.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@printers/printers",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Cross-platform printer library for Node.js, Deno, and Bun",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
Uses NPM Trusted Publisher provenance expectations where only a tag push can generate a new publish. Release tag creation is now a restricted action too.