### PR TITLE
Fix bad repo link in package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,3 +362,5 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "printers-js"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "lazy_static",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "printers-js"
 authors = ["Evan Simkowitz <esimkowitz@users.noreply.github.com>"]
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 publish = false
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@printers/printers",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "license": "MIT",
   "exports": {
     ".": "./index.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@printers/printers",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@printers/printers",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "devDependencies": {
         "@cross/test": "npm:@jsr/cross__test@^0.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@printers/printers",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Cross-platform printer library for Node.js, Deno, and Bun",
   "type": "module",
   "main": "index.ts",
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/printers/printers-js.git"
+    "url": "https://github.com/esimkowitz/printers-js.git"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
The package.json git repo link was wrong, which was causing the provenance check to fail. I need to temporarily revert to the standard publish method to correct the repo link before reenabling and trying the trusted publish again.