### PR TITLE
Fix CI: bump napi-derive to 3.5.4 and group napi crates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
       day: "friday"
       time: "09:00"
       timezone: "America/Los_Angeles"
+    groups:
+      napi:
+        patterns:
+          - "napi"
+          - "napi-derive"
+          - "napi-build"
+          - "napi-sys"
   - package-ecosystem: "devcontainers" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,29 +43,13 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
-dependencies = [
- "ctor-proc-macro 0.0.7",
- "dtor 0.3.0",
-]
-
-[[package]]
-name = "ctor"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
 dependencies = [
- "ctor-proc-macro 0.0.12",
- "dtor 0.7.0",
+ "ctor-proc-macro",
+ "dtor",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -75,27 +59,12 @@ checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
 
 [[package]]
 name = "dtor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
-dependencies = [
- "dtor-proc-macro 0.0.6",
-]
-
-[[package]]
-name = "dtor"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
 dependencies = [
- "dtor-proc-macro 0.0.12",
+ "dtor-proc-macro",
 ]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dtor-proc-macro"
@@ -351,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa73b028610e2b26e9e40bd2c8ff8a98e6d7ed5d67d89ebf4bfd2f992616b024"
 dependencies = [
  "bitflags",
- "ctor 0.10.0",
+ "ctor",
  "futures",
  "napi-build",
  "napi-sys",
@@ -367,12 +336,12 @@ checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.3"
+version = "3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60867ff9a6f76e82350e0c3420cb0736f5866091b61d7d8a024baa54b0ec17dd"
+checksum = "7430702d3cc05cf55f0a2c9e41d991c3b7a53f91e6146a8f282b1bfc7f3fd133"
 dependencies = [
  "convert_case",
- "ctor 0.8.0",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -381,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.2"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0864cf6a82e2cfb69067374b64c9253d7e910e5b34db833ed7495dda56ccb18"
+checksum = "1ca5a083f2c9b49a0c7d33ec75c083498849c6fcc46f5497317faa39ea77f5d5"
 dependencies = [
  "convert_case",
  "proc-macro2",


### PR DESCRIPTION
## Summary
- Bumps `napi-derive` 3.5.3 → 3.5.4 in `Cargo.lock` to fix the broken `main` CI build — `napi 3.8.5`'s `register_class` requires 5 args, but `napi-derive 3.5.3` (via backend 5.0.2) emits only 4, so every `#[napi]` class expansion failed to compile.
- Groups `napi`, `napi-derive`, `napi-build`, and `napi-sys` under a single Dependabot group so future sibling bumps land atomically and can't drift into incompatible combinations again.
- No changes to `lib/napi.rs` or `Cargo.toml` — the source was correct; only the resolved lockfile was broken.

## Root cause
Dependabot #263 (napi 3.8.3→3.8.4, re-resolved to 3.8.5) and #264 (napi-derive 3.5.2→3.5.3) merged independently. Each PR's CI was green at its own merge time, but the resulting combination on `main` is incompatible — `napi-derive 3.5.3`'s backend emits 4-arg `register_class(...)` calls while `napi 3.8.5`'s runtime declares a 5-arg signature (new `implement_iterator: bool` param).

Failing run: https://github.com/esimkowitz/printers-js/actions/runs/24694343404

## Test plan
- [x] `cargo check --all-targets` — clean
- [x] `task build` — N-API module builds successfully on darwin-arm64
- [x] `task test` — all runtimes pass (rust, deno, node 44/44, bun)
- [ ] CI green on ubuntu-latest, macos-latest, windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Rust N-API macro/runtime dependencies and lockfile resolution, which could subtly change generated bindings or build behavior across platforms. No application source changes, but CI/build stability depends on the new crate versions.
> 
> **Overview**
> Fixes CI breakage by updating the resolved Rust N-API proc-macro stack in `Cargo.lock` (notably `napi-derive` `3.5.3`→`3.5.4` and `napi-derive-backend` `5.0.2`→`5.0.3`, plus related `ctor`/`dtor` resolution cleanup).
> 
> Updates `.github/dependabot.yml` to **group `napi*` Cargo crates** (`napi`, `napi-derive`, `napi-build`, `napi-sys`) so future Dependabot bumps land together and avoid version drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c593c895f31b71251266739b6c327950ec4e81eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->