### PR TITLE
chore: bump package version to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "printers-js"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "lazy_static",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "printers-js"
 authors = ["Evan Simkowitz <esimkowitz@users.noreply.github.com>"]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 publish = false
 

--- a/lib/core.rs
+++ b/lib/core.rs
@@ -837,7 +837,7 @@ impl PrinterJobTracking for Printer {
             .collect();
 
         // Sort by creation time (most recent first)
-        jobs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        jobs.sort_by_key(|job| std::cmp::Reverse(job.created_at));
 
         if let Some(limit) = limit {
             jobs.truncate(limit);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@printers/printers",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@printers/printers",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@cross/test": "npm:@jsr/cross__test@^0.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@printers/printers",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cross-platform printer library for Node.js, Deno, and Bun",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a version bump across Rust and npm metadata with a small, behavior-equivalent refactor to job history sorting.
> 
> **Overview**
> Bumps the package version from `1.2.0` to `1.2.1` across Rust (`Cargo.toml`/`Cargo.lock`) and npm (`package.json`/`package-lock.json`).
> 
> Refactors `PrinterJobTracking::get_job_history` sorting to use `sort_by_key(Reverse(created_at))` instead of a custom comparator, preserving “most recent first” ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db7527ccd7f5e4ef11a9e15ee5c17fa50a61c04f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->