### PR TITLE
Deno and Bun now support Windows on ARM, bump major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,9 @@ updates:
       timezone: "America/Los_Angeles"
     cooldown:
       default-days: 2
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "rust-toolchain" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,6 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: windows-11-arm
             target: aarch64-pc-windows-msvc
-            test_runtimes: rust node
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - host: ubuntu-24.04-arm
@@ -143,14 +142,12 @@ jobs:
           sudo apt-get install -y libcups2-dev pkg-config clang
       - uses: actions/checkout@v6
       - name: Setup Deno
-        if: matrix.settings.target != 'aarch64-pc-windows-msvc' # Deno does not support Windows ARM yet
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
           cache: false
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        if: matrix.settings.target != 'aarch64-pc-windows-msvc' # Deno does not support Windows ARM yet
         with:
           bun-version: latest
           no-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,9 +191,6 @@ jobs:
           if [ "${{ matrix.node }}" != "${{ needs.setup.outputs.primary-node }}" ]; then
             echo "Running Node-only tests for Node ${{ matrix.node }}"
             task test -- node
-          elif [ -n "${{ matrix.settings.test_runtimes }}" ]; then
-            echo "Running selective runtime tests: ${{ matrix.settings.test_runtimes }}"
-            task test -- ${{ matrix.settings.test_runtimes }}
           else
             echo "Running all runtime tests"
             task test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "printers-js"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "lazy_static",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "printers-js"
 authors = ["Evan Simkowitz <esimkowitz@users.noreply.github.com>"]
-version = "1.2.1"
+version = "2.0.0"
 edition = "2021"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ console.log("Simulation mode:", isSimulationMode);
 | OS      | Architecture | Node.js | Deno | Bun |
 | ------- | ------------ | ------- | ---- | --- |
 | Windows | x64          | ✅      | ✅   | ✅  |
-| Windows | ARM64        | ✅      | ❌   | ❌  |
+| Windows | ARM64        | ✅      | ✅   | ✅  |
 | macOS   | x64          | ✅      | ✅   | ✅  |
 | macOS   | ARM64        | ✅      | ✅   | ✅  |
 | Linux   | x64          | ✅      | ✅   | ✅  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@printers/printers",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Cross-platform printer library for Node.js, Deno, and Bun",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Updating the support matrix and allowing Deno/Bun tests to run on the Windows ARM64 runner in the release validation tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release/CI validation coverage and bumps a major version, though it doesn’t modify runtime library code paths.
> 
> **Overview**
> **Enables Windows ARM64 support for Deno/Bun in release validation.** The `release.yml` workflow now runs the full cross-runtime test suite on the Windows ARM64 runner (no longer skipping Deno/Bun setup or selectively limiting runtimes).
> 
> **Ships a major version bump.** Versions are updated from `1.2.1` to `2.0.0` across `package.json`, `Cargo.toml`/`Cargo.lock`, and the README support matrix is updated to mark Windows ARM64 as supported for Deno and Bun.
> 
> Dependabot is also configured to ignore semver-major updates for `@types/node`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd49fcae1c767fd1493122e0460e8d5d8b2d8ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->