### PR TITLE
chore: update examples to 2.0.0

### DIFF
--- a/examples/bun/bunfig.toml
+++ b/examples/bun/bunfig.toml
@@ -2,6 +2,7 @@
 # Configure Bun package manager behavior
 cache = true
 exact = false
+minimumReleaseAge = 172800
 
 [run]
 # Environment variables for running scripts

--- a/examples/bun/package.json
+++ b/examples/bun/package.json
@@ -9,7 +9,7 @@
     "dev": "bun --watch main.ts"
   },
   "dependencies": {
-    "@printers/printers": "^1.1"
+    "@printers/printers": "^2.0.0"
   },
   "engines": {
     "bun": ">= 1.0"

--- a/examples/deno/deno.json
+++ b/examples/deno/deno.json
@@ -9,6 +9,7 @@
     "@std/path": "jsr:@std/path@^1.1.2"
   },
   "nodeModulesDir": "auto",
+  "minimumDependencyAge": "P2D",
   "compilerOptions": {
     "strict": true
   }

--- a/examples/deno/deno.json
+++ b/examples/deno/deno.json
@@ -5,7 +5,7 @@
   },
   "imports": {
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.7",
-    "@printers/printers": "npm:@printers/printers@^1.1",
+    "@printers/printers": "npm:@printers/printers@^2.0.0",
     "@std/path": "jsr:@std/path@^1.1.2"
   },
   "nodeModulesDir": "auto",

--- a/examples/node/.npmrc
+++ b/examples/node/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,10 +9,10 @@
     "dev": "node --watch main.js"
   },
   "dependencies": {
-    "@printers/printers": "^1.1"
+    "@printers/printers": "^2.0.0"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to example project configs (dependency/version bumps and package-manager settings) with no runtime logic modifications.
> 
> **Overview**
> Updates the Bun, Deno, and Node example projects to use `@printers/printers@^2.0.0`.
> 
> Adds package-manager “minimum release/dependency age” settings (`minimumReleaseAge` in `bunfig.toml`, `minimumDependencyAge` in `deno.json`, and `min-release-age` via a new `.npmrc`), and raises the Node example’s required engine version to `node >= 22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfba0e49b396a0ae6033fd78e0ed07c531b07bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->