### PR TITLE
ci(release): pin publish job to Node 24 for npm OIDC trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version-file: .node-version
+          node-version: '24'
           registry-url: https://registry.npmjs.org/
           cache: pnpm
       - name: Install Node.js dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: "24"
           registry-url: https://registry.npmjs.org/
           cache: pnpm
       - name: Install Node.js dependencies


### PR DESCRIPTION
Node 22 ships npm 10.9.x, which lacks OIDC trusted publisher support (introduced in npm 11.5.1). #274 unintentionally regressed the publish job from node-version: 24 to node-version-file: .node-version (= 22), causing v2.0.0 publish to fail with 404 because no NPM_TOKEN exists and the OIDC handshake never ran.

Restore node-version: 24 on the publish job only. Build/test jobs continue to use .node-version so the minimum-supported-runtime guarantee remains tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change limited to the release publish job’s Node version selection. Main risk is only if Node 24 introduces unexpected publish-time behavior, but build/test jobs remain unchanged.
> 
> **Overview**
> **Release publishing now runs on Node 24 explicitly.** The `publish` job in `.github/workflows/release.yml` switches from `node-version-file: .node-version` to `node-version: "24"` so the npm client used during `pnpm publish` supports OIDC trusted publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ade6eca4b62987ca451ceb065c2dc75aa32ac40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->